### PR TITLE
Neutral terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Content | Limit to 500 words.
 Language | Write in the form of a continuous prose.
 Language | Use singular first-person pronouns and address readers as second person.
 Language | Omit contractions.
+Language | Avoid AISG terminology.
 Formatting | Insert snippet for contributors at the top of your content.
 Formatting | Adhere to PEP 8 for Markdown files (line lengths), code and Jupyter Notebooks.
 Formatting | Use MyST flavour for Markdown documents. For notebooks, pair using Jupytext.
@@ -226,6 +227,9 @@ tone for contributions:
 - Do address readers as second person.
   Example: "__you__ may encounter..."
 - Avoid contractions. Example: "let us" instead of "let's".
+- Avoid AISG-specific terminology, e.g., "100E", "AI Apprentices". Use neutral 
+alternatives such as "AI/ML project" and "junior developers", respectively, that
+a general, external audience can better understand.
 
 This is a collective effort and everyone has a
 part to play in maintaining the quality of the book.

--- a/book/markdown-template.md
+++ b/book/markdown-template.md
@@ -20,6 +20,8 @@ Singular first person pronouns should be used; while readers can be addressed in
 
 Contractions should be avoided (e.g., "let us" instead of "let's").
 
+Avoid AISG-specific terminology, e.g., "100E", "AI Apprentices". Use neutral alternatives such as "AI/ML project" and "junior developers", respectively, that a general, external audience can better understand.
+
 Contributions shall be written in Singaporean Standard English, which uses British spelling.
 
 ## Code blocks, figures and tables

--- a/book/markdown-template.md
+++ b/book/markdown-template.md
@@ -4,7 +4,7 @@ Contributor: Kenny WJ Chua
 
 ---
 
-This is a Markdown template/contribution guide for a section within a chapter. Alternatively, sections can be written in [Jupyter notebooks](../notebooks/notebook-template.ipynb)
+This is a Markdown template/contribution guide for a section within a chapter. Alternatively, sections can be written in [Jupyter notebooks](../notebooks/notebook-template.ipynb).
 
 ## Content
 We want to focus on content that can stand the test of time. Examples include process frameworks, general principles, strategies and design patterns.

--- a/book/markdown-template.md
+++ b/book/markdown-template.md
@@ -4,7 +4,7 @@ Contributor: Kenny WJ Chua
 
 ---
 
-This is a Markdown template/contribution guide for a section within a chapter. Alternatively, sections can be written in [Jupyter notebooks](../notebooks/notebook-template.ipynb).
+This is a Markdown template/contribution guide for a section within a chapter. Alternatively, sections can be written in [Jupyter notebooks](../notebooks/notebook-template.ipynb)
 
 ## Content
 We want to focus on content that can stand the test of time. Examples include process frameworks, general principles, strategies and design patterns.

--- a/book/notebook-template.md
+++ b/book/notebook-template.md
@@ -41,6 +41,8 @@ Singular first person pronouns should be used; while readers can be addressed in
 
 Contractions should be avoided (e.g., "let us" instead of "let's").
 
+Avoid AISG-specific terminology, e.g., "100E", "AI Apprentices". Use neutral alternatives such as "AI/ML project" and "junior developers", respectively, that a general, external audience can better understand.
+
 Contributions shall be written in Singaporean Standard English, which uses British spelling.
 
 

--- a/notebooks/notebook-template.ipynb
+++ b/notebooks/notebook-template.ipynb
@@ -71,6 +71,8 @@
     "\n",
     "Contractions should be avoided (e.g., \"let us\" instead of \"let's\").\n",
     "\n",
+    "Avoid AISG-specific terminology, e.g., \"100E\", \"AI Apprentices\". Use neutral alternatives such as \"AI/ML project\" and \"junior developers\", respectively, that a general, external audience can better understand.\n",
+    "\n",
     "Contributions shall be written in Singaporean Standard English, which uses British spelling."
    ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ numpy==1.23.1
 pandas==1.4.3
 pillow==9.2.0
 pip==22.1.2
+proselint==0.13.0
 pygments==2.12.0
 python-dateutil==2.8.2
 pyyaml==6.0


### PR DESCRIPTION
Added contribution guidelines to avoid AISG-specific terminology. Also found out that proselint had somehow disappeared from `requirements.txt` in main branch--I've restored it here.