### PR TITLE
Suppress proselint failures

### DIFF
--- a/.github/workflows/proselint.yml
+++ b/.github/workflows/proselint.yml
@@ -36,6 +36,7 @@ jobs:
 
     # Run English language linter
     - name: Run proselint
+      continue-on-error: true
       run: |
         for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
           proselint $file


### PR DESCRIPTION
This suppresses the pipeline failure icon when proselint fails. The implication is that there will be no indication of proselint failure at the overview level, and contributors will have to actively look into the details to review proselint outputs.